### PR TITLE
Support for passing directory as a source

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ npm install --save gulp-fontcustom
 var gulp = require('gulp'),
     fontcustom = require('gulp-fontcustom')
 
-gulp.src("./icons/*.svg")
+gulp.src("./icons")
 .pipe(fontcustom({
-  font_name: 'myfont'  // defaults to 'fontcustom'
+  font_name: 'myfont',  // defaults to 'fontcustom',
+  'css-selector': '.prefix-{{glyph}}'
 }))
 .pipe(gulp.dest("./results"))
 ```

--- a/index.js
+++ b/index.js
@@ -78,8 +78,9 @@ module.exports = function(options) {
   */
   var collectIcons = function(source, enc, done) {
     var stream = this
+    var notDir = !source.isDirectory()
 
-    if(source.isNull()) {
+    if(notDir && source.isNull()) {
       stream.push(source)
       return done()
     }
@@ -89,12 +90,12 @@ module.exports = function(options) {
       return done()
     }
 
-    if('.svg' !== path.extname(source.path)) {
+    if(notDir && '.svg' !== path.extname(source.path)) {
       stream.push(source)
       return done()
     }
 
-    var input = path.dirname(source.path),
+    var input = notDir ? path.dirname(source.path) : source.path,
         args = toArgumentArray(options)
 
     // fontcustom compile /___tmp___ --output <output> [other options]


### PR DESCRIPTION
This PR is related to issue #1. 

It seems there is no need to pass a list of svg files as `fontcustom` requires a directory.
I've added support for passing a directory as a source to the plugin, as this is exactly what we needed to mitigate #1.

I have also added an example of how to pass `css-selector` option to the README.md.